### PR TITLE
chore: add repository meta

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @matootie

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing guidelines
+
+Thank you for your interest in contributing to Yoik.ME. Please refer to the
+project issues page and discussions to find tasks to participate in. When you're
+ready for a code change, create a branch and submit a pull request.
+
+## Pull requests
+
+### Labels
+
+Every pull request must be labeled with the service or package it impacts:
+
+| Label | Description |
+| --- | --- |
+| `client` | Changes to the client service |
+| `tsconfig` | Changes to the tsconfig package |
+| `config` | Changes to tooling configuration |
+| `ci` | Changes to CI/CD workflows |
+
+Additionally, label the pull request with the type of change:
+
+| Label | Description |
+| --- | --- |
+| `bug` | Something isn't working |
+| `enhancement` | New feature or improvement |
+| `fix` | Patch for a bug |
+| `dependency` | Dependency bump or replacement |
+| `documentation` | Updates to docs |
+| `duplicate` | Duplicate issue or PR |
+| `question` | Questionable issue requiring discussion |
+| `wontfix` | Will not be worked on |
+
+### Assignees and reviewers
+
+- Assign yourself to the pull request.
+- Add the appropriate code owner as a reviewer.
+
+### PR body
+
+Use the pull request template provided in this repository. At minimum, every PR
+should include an issue reference (or N/A), a description of the change, and
+any additional context that helps reviewers understand the change.
+
+## Code owners
+
+See [CODEOWNERS](.github/CODEOWNERS) for the current ownership map.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Report a bug or something that isn't working
+title: ""
+labels: bug
+assignees: ""
+---
+
+### Describe the bug
+
+<!--
+
+A clear and concise description of what the bug is.
+
+-->
+
+### Steps to reproduce
+
+<!--
+
+Outline steps to reproduce the behaviour.
+
+-->
+
+### Expected behaviour
+
+<!--
+
+Describe what you expected to happen.
+
+-->
+
+### Additional context
+
+<!--
+
+Add any other context, screenshots, or screen recordings that help illustrate
+the problem. If unnecessary, write N/A or remove this section.
+
+-->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,41 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+### Description
+
+<!--
+
+A clear and concise description of the feature or improvement you'd like.
+
+-->
+
+### Motivation
+
+<!--
+
+Why is this change needed? What problem does it solve or what value does it add?
+
+-->
+
+### Proposed solution
+
+<!--
+
+If you have a specific idea for how this should be implemented, describe it here.
+If not, remove this section.
+
+-->
+
+### Additional context
+
+<!--
+
+Any other context, mockups, or references that help illustrate the request.
+If unnecessary, write N/A or remove this section.
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+### Issue reference
+
+<!--
+
+Reference the issue or issues that this pull request is meant to solve. Use
+closing tags to have GitHub automatically close the issues when the pull
+request is merged.
+
+Good examples are:
+- Closes #
+- Fixes #
+- Resolves #
+
+https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
+
+If there is no related issue, write N/A or remove this section.
+
+-->
+
+### Description of the change
+
+<!--
+
+In a short paragraph describe what you've done to solve or implement the
+changes. If there is no issue reference, explain in detail why this code
+change was put together.
+
+-->
+
+### Additional context
+
+<!--
+
+Alternate design possibilities, possible drawbacks, or anything necessary
+to reassure reviewers that the changes are valid. Screenshots or video
+showing the changes in action are helpful. If unnecessary, write N/A or
+remove this section.
+
+-->

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,3 +1,36 @@
 # Yoik.ME
 
-Coming August 2018
+An anonymous microblogging platform. Post short thoughts, see what others are thinking.
+
+## Stack
+
+- **Client:** React 18, TypeScript, Vite, Tailwind CSS
+- **Data:** Firebase (Firestore + Anonymous Auth)
+- **Monorepo:** Yarn Workspaces + Turborepo
+
+## Getting started
+
+```bash
+# Install dependencies
+yarn
+
+# Start the development server
+yarn develop
+```
+
+The client runs at [http://localhost:3000](http://localhost:3000).
+
+## Project structure
+
+```
+yoik.me/
+├── packages/
+│   └── tsconfig/       Shared TypeScript configurations
+├── services/
+│   └── client/         React SPA (Vite)
+└── config/             Prettier, Commitlint, Husky
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for guidelines on pull requests, labels, and code ownership.


### PR DESCRIPTION
### Issue reference

N/A

### Description of the change

Adds repository metadata inspired by kwotapp/kwot's .github setup:

- **CODEOWNERS** — assigns @matootie as default code owner
- **CONTRIBUTING.md** — pull request guidelines, labeling conventions, reviewer/assignee expectations
- **PULL_REQUEST_TEMPLATE.md** — structured PR template (issue ref, description, context)
- **ISSUE_TEMPLATE/bug.md** — bug report template with repro steps and expected behaviour
- **ISSUE_TEMPLATE/feature.md** — feature request template with motivation and proposed solution
- **README.md** — updated from placeholder to actual project overview with stack, setup, and structure

### Additional context

Labels adapted for yoik.me's monorepo structure (client, tsconfig, config, ci) rather than kwot's service names.