### PR TITLE
fix: use dynamic viewport height for iOS scroll compatibility

### DIFF
--- a/services/client/src/pages/home.tsx
+++ b/services/client/src/pages/home.tsx
@@ -11,7 +11,7 @@ import { PostsList } from "#components/posts"
  */
 export function HomePage() {
   return (
-    <div className="h-screen flex flex-col">
+    <div className="h-dvh flex flex-col">
       <Header
         title="Posts"
         withPostButton


### PR DESCRIPTION
### Issue reference

Closes #2

### Description

Replaces `h-screen` (100vh) with `h-dvh` (100dvh) in the home page layout. On iOS Safari, `100vh` includes the area behind the browser chrome (address bar/toolbar), causing the page to be taller than the visible viewport. This results in unwanted scrolling behavior.

`100dvh` (dynamic viewport height) adjusts to the actual visible area, resolving the scroll issue on iOS.

### Changes
- `services/client/src/pages/home.tsx`: `h-screen` → `h-dvh`