### PR TITLE
fix: await setPersistence before anonymous sign-in

### DIFF
--- a/services/client/src/utils/auth.tsx
+++ b/services/client/src/utils/auth.tsx
@@ -185,7 +185,7 @@ function useProvideAuth(): AuthState {
     setError(undefined)
     const auth = getAuth()
     try {
-      setPersistence(auth, browserLocalPersistence)
+      await setPersistence(auth, browserLocalPersistence)
       const { user } = await signInAnonymously(auth)
       setUser({
         ...user,


### PR DESCRIPTION
### Issue reference

Closes #3

### Description

`setPersistence(auth, browserLocalPersistence)` was not being awaited before calling `signInAnonymously()`. This race condition could result in the anonymous identity being stored with the wrong persistence type, causing identity loss when opening the app in multiple tabs.

### Changes
- `services/client/src/utils/auth.tsx`: Added `await` to `setPersistence()` call