### PR TITLE
fix: trigger infinite scroll when items fit within viewport

### DIFF
--- a/services/client/src/components/posts/posts-list.tsx
+++ b/services/client/src/components/posts/posts-list.tsx
@@ -3,7 +3,7 @@
  */
 
 // External imports.
-import { useRef } from "react"
+import { useEffect, useRef } from "react"
 
 // Component imports.
 import { LoadingSpinner } from "#components/loading-spinner"
@@ -42,6 +42,16 @@ export function PostsList({ className = "" }: PostListProps) {
       fetchNextPage()
     }
   }
+
+  // If items fit within the viewport, no scroll event fires.
+  // Check after data loads and fetch next page if needed.
+  useEffect(() => {
+    const ref = scrollBoxRef.current
+    if (!ref || isLoading || isFetchingNextPage || !hasNextPage) return
+    if (ref.scrollHeight <= ref.clientHeight) {
+      fetchNextPage()
+    }
+  }, [data, isLoading, isFetchingNextPage, hasNextPage])
 
   // Return JSX.
   return (


### PR DESCRIPTION
### Issue reference

Closes #4

### Description

When the first page of posts fits entirely within the viewport, the scroll container has no overflow, so the `onScroll` handler never fires and `fetchNextPage` is never called.

Added a `useEffect` that runs after data loads to check if `scrollHeight <= clientHeight`. If so, it triggers `fetchNextPage()` automatically, filling the viewport until scrolling becomes possible or there are no more pages.

### Changes
- `services/client/src/components/posts/posts-list.tsx`: Added useEffect for viewport-fit detection