### PR TITLE
feat: set up CI/CD with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [trunk]
+  pull_request:
+    branches: [trunk]
+
+jobs:
+  lint-and-test:
+    name: Lint & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.8"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check (client)
+        run: cd services/client && bunx tsc --noEmit
+
+      - name: Type check (api)
+        run: cd services/api && bunx tsc --noEmit
+
+      - name: Run tests
+        run: bunx turbo run test
+
+      - name: Format check
+        run: bunx prettier --check --config config/.prettierrc.json "**/*.{ts,tsx,json,md}"


### PR DESCRIPTION
### Issue reference

Closes #12

### Description

Adds a GitHub Actions CI workflow that runs on every push to trunk and on pull requests.

#### Pipeline steps
1. Checkout code
2. Setup Bun 1.3.8
3. Install dependencies (frozen lockfile)
4. TypeScript type check (client + API)
5. Run all tests via Turbo
6. Prettier format check

### Changes
- `.github/workflows/ci.yml`: New CI workflow