### PR TITLE
fix: install functions deps outside monorepo to avoid workspace:* protocol error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,8 +62,16 @@ jobs:
       - name: Bundle Cloud Functions
         run: cd functions && node build.mjs
 
-      - name: Install functions dependencies
-        run: cd functions && npm install --production
+      - name: Install functions production dependencies
+        run: |
+          # Copy functions dir outside the monorepo so npm doesn't
+          # walk up and encounter workspace:* protocol references.
+          cp -r functions /tmp/functions-stage
+          cd /tmp/functions-stage
+          npm install --omit=dev
+          # Copy the resolved node_modules back
+          rm -rf $GITHUB_WORKSPACE/functions/node_modules
+          cp -r node_modules $GITHUB_WORKSPACE/functions/node_modules
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,3 +1,3 @@
 lib/
 node_modules/
-functions/package-lock.json
+package-lock.json

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,2 +1,3 @@
 lib/
 node_modules/
+functions/package-lock.json


### PR DESCRIPTION
## Problem

The Deploy workflow fails at the `npm install --production` step in `functions/` because npm walks up to the monorepo root and encounters `workspace:*` protocol references in sibling packages (`@yme/types`, `@yme/tsconfig`), causing `EUNSUPPORTEDPROTOCOL` errors.

## Solution

Copy the `functions/` directory to a temp location outside the monorepo before running `npm install`, then copy the resolved `node_modules` back. This isolates npm from the Bun workspace context.

Also:
- Use `--omit=dev` instead of deprecated `--production` flag
- Add `package-lock.json` to functions `.gitignore`

Closes the deploy failure on trunk.