### PR TITLE
fix: upgrade Cloud Functions runtime to Node.js 22

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
       "version": "0.0.0",
       "dependencies": {
         "firebase-admin": "^13.4.0",
-        "firebase-functions": "^6.3.0",
+        "firebase-functions": "^7.0.6",
       },
       "devDependencies": {
         "esbuild": "^0.27.3",
@@ -1348,8 +1348,6 @@
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
-
-    "@yme/functions/firebase-functions": ["firebase-functions@6.6.0", "", { "dependencies": { "@types/cors": "^2.8.5", "@types/express": "^4.17.21", "cors": "^2.8.5", "express": "^4.21.0", "protobufjs": "^7.2.2" }, "peerDependencies": { "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0" }, "bin": { "firebase-functions": "lib/bin/firebase-functions.js" } }, "sha512-wwfo6JF+N7HUExVs5gUFgkgVGHDEog9O+qtouh7IuJWk8TBQ+KwXEgRiXbatSj7EbTu3/yYnHuzh3XExbfF6wQ=="],
 
     "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 

--- a/firebase.json
+++ b/firebase.json
@@ -17,7 +17,7 @@
     {
       "source": "functions",
       "codebase": "default",
-      "runtime": "nodejs20",
+      "runtime": "nodejs22",
       "ignore": [
         "node_modules",
         ".git",

--- a/functions/package.json
+++ b/functions/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "main": "lib/index.js",
   "engines": {
-    "node": "20"
+    "node": "22"
   },
   "dependencies": {
     "firebase-admin": "^13.4.0",
-    "firebase-functions": "^6.3.0"
+    "firebase-functions": "^7.0.6"
   },
   "devDependencies": {
     "esbuild": "^0.27.3"


### PR DESCRIPTION
- Update `firebase.json` runtime from `nodejs20` to `nodejs22`
- Update `functions/package.json` engines from node 20 to 22
- Upgrade `firebase-functions` from ^6.3.0 to ^7.0.6
- No breaking changes: codebase uses only v2 APIs

Closes #29