### PR TITLE
fix: use correct env prefix for API base URL in production

### DIFF
--- a/services/client/.env.development
+++ b/services/client/.env.development
@@ -1,0 +1,5 @@
+# Local development overrides — loaded automatically by Vite in dev mode.
+# See https://vite.dev/guide/env-and-mode
+
+# Point API requests at the local Bun dev server (services/api).
+CLIENT_API_URL=http://localhost:3001

--- a/services/client/src/utils/api.test.ts
+++ b/services/client/src/utils/api.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for the API client utilities.
+ *
+ * The `resolveApiBase` function is exported specifically for testability —
+ * it encapsulates the env-var-to-URL logic without requiring module
+ * reloads or Vite env stubbing.
+ */
+
+import { describe, it, expect } from "vitest"
+import { resolveApiBase } from "./api"
+
+describe("resolveApiBase", () => {
+  it("uses CLIENT_API_URL when provided, regardless of mode", () => {
+    expect(
+      resolveApiBase({ CLIENT_API_URL: "https://staging.example.com" })
+    ).toBe("https://staging.example.com")
+    expect(
+      resolveApiBase({
+        CLIENT_API_URL: "https://staging.example.com",
+        PROD: true,
+      })
+    ).toBe("https://staging.example.com")
+    expect(
+      resolveApiBase({
+        CLIENT_API_URL: "https://staging.example.com",
+        PROD: false,
+      })
+    ).toBe("https://staging.example.com")
+  })
+
+  it("returns empty string in production (relative URLs for Firebase Hosting rewrites)", () => {
+    expect(resolveApiBase({ PROD: true })).toBe("")
+  })
+
+  it("returns localhost dev server URL in development", () => {
+    expect(resolveApiBase({ PROD: false })).toBe("http://localhost:3001")
+    expect(resolveApiBase({})).toBe("http://localhost:3001")
+  })
+
+  it("respects explicit empty string (forces relative URLs in any mode)", () => {
+    expect(resolveApiBase({ CLIENT_API_URL: "", PROD: false })).toBe("")
+    expect(resolveApiBase({ CLIENT_API_URL: "" })).toBe("")
+  })
+})

--- a/services/client/src/utils/api.ts
+++ b/services/client/src/utils/api.ts
@@ -1,10 +1,39 @@
 /**
  * API client utilities.
+ *
+ * In production the client is served by Firebase Hosting, which rewrites
+ * `/api/**` requests to the Cloud Function.  An empty API_BASE (the default
+ * for production builds) produces relative URLs that go through the rewrite
+ * automatically.
+ *
+ * In development the local Bun dev server runs on port 3001, so the fallback
+ * points there unless overridden via a `CLIENT_API_URL` env var.
+ *
+ * Note: Vite is configured with `envPrefix: "CLIENT_"`, so only env vars
+ * starting with `CLIENT_` are exposed to client code via `import.meta.env`.
  */
 
 import { getAuth } from "#utils/firebase"
 
-const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:3001"
+/**
+ * Resolve the API base URL from the environment.
+ *
+ * Priority:
+ * 1. Explicit `CLIENT_API_URL` env var (allows overrides for staging, etc.)
+ * 2. Production builds → empty string (relative URLs; Firebase Hosting
+ *    rewrites `/api/**` to the Cloud Function)
+ * 3. Development → `http://localhost:3001` (local Bun dev server)
+ *
+ * Uses nullish coalescing (`??`) so an explicit empty string is respected.
+ */
+export function resolveApiBase(env: {
+  CLIENT_API_URL?: string
+  PROD?: boolean
+}): string {
+  return env.CLIENT_API_URL ?? (env.PROD ? "" : "http://localhost:3001")
+}
+
+const API_BASE = resolveApiBase(import.meta.env)
 
 /**
  * Get the current user's ID token for API authentication.

--- a/services/client/vite.config.ts
+++ b/services/client/vite.config.ts
@@ -17,7 +17,7 @@ import tailwindcss from "@tailwindcss/vite"
  */
 export default defineConfig({
   root: join(__dirname, "./src"),
-  envDir: ".",
+  envDir: __dirname,
   envPrefix: "CLIENT_",
   publicDir: join(__dirname, "./public"),
   clearScreen: false,


### PR DESCRIPTION
### Issue reference

Fixes #31

### Description of the change

The production web app was hitting `localhost:3001` for all API requests instead of using the production Cloud Functions endpoint. The root cause was a mismatch between the Vite env var prefix configuration and the env var name used in the API client:

1. `vite.config.ts` sets `envPrefix: "CLIENT_"` — only env vars starting with `CLIENT_` are exposed to client code via `import.meta.env`
2. `api.ts` was reading `import.meta.env.VITE_API_URL` (wrong prefix), which was always `undefined`
3. The fallback `"http://localhost:3001"` kicked in unconditionally, even in production

**Fix:**
- Changed the env var to `CLIENT_API_URL` (matching the configured prefix)
- Added mode-aware defaults: empty string in production (relative URLs route through Firebase Hosting rewrites to the Cloud Function), `http://localhost:3001` in development
- Fixed `envDir` in `vite.config.ts` to resolve to the package root instead of `src/` so `.env` files are found correctly
- Added `.env.development` for local dev convenience
- Extracted `resolveApiBase()` as a testable pure function with unit tests

### Additional context

The production build correctly tree-shakes the dev default — verified that `localhost:3001` does not appear in the production bundle. The resolved production value is `""` (empty string), producing relative URLs like `/api/posts` which Firebase Hosting rewrites to the `api` Cloud Function.