### PR TITLE
fix(api): use req.rawBody instead of stream to read request body

### DIFF
--- a/services/api/src/functions.ts
+++ b/services/api/src/functions.ts
@@ -23,24 +23,12 @@ export const api = onRequest(
         headers.set(key, Array.isArray(value) ? value.join(", ") : value)
     }
 
+    // Cloud Functions v2 pre-parses the request body, so the raw stream is
+    // already consumed. Use `req.rawBody` (a Buffer provided by the runtime)
+    // instead of reading from the stream, which would hang forever.
     const body =
       req.method !== "GET" && req.method !== "HEAD"
-        ? await new Promise<Uint8Array>((resolve) => {
-            const chunks: Uint8Array[] = []
-            req.on("data", (chunk: Buffer) =>
-              chunks.push(new Uint8Array(chunk))
-            )
-            req.on("end", () => {
-              const total = chunks.reduce((n, c) => n + c.length, 0)
-              const merged = new Uint8Array(total)
-              let offset = 0
-              for (const c of chunks) {
-                merged.set(c, offset)
-                offset += c.length
-              }
-              resolve(merged)
-            })
-          })
+        ? (req as any).rawBody || undefined
         : undefined
 
     const webRequest = new Request(url, {


### PR DESCRIPTION
## Problem
POST requests to the Cloud Function hang for 60s then return 502. GET requests work fine.

## Root Cause
The body reading code in `functions.ts` uses Node.js stream events (`req.on('data')`, `req.on('end')`). Cloud Functions v2 pre-parses the request body — the raw stream is already consumed by the time our handler runs, so those events never fire and the Promise hangs forever.

## Fix
Replace the stream-based body reading with `req.rawBody`, a Buffer that Cloud Functions provides with the already-parsed raw request body.