### PR TITLE
feat: add end-to-end API test suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,15 +3,14 @@ name: E2E Tests
 on:
   pull_request:
     branches: [trunk]
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
 
 jobs:
-  # Run e2e tests against Firebase emulators (functions + firestore + hosting).
+  # Run e2e tests against Firebase emulators (auth + functions + firestore + hosting).
   # The hosting emulator applies the same rewrite rules as production, so the
   # test suite hits identical URL paths without touching real infrastructure.
   e2e:
     name: Run E2E Tests
-    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -28,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Setup Java 21
         uses: actions/setup-java@v4
@@ -59,59 +58,25 @@ jobs:
       - name: Start Firebase emulators
         run: |
           bunx firebase-tools emulators:start \
-            --only functions,firestore,hosting \
+            --only auth,functions,firestore,hosting \
             --project yoikme &
           # Wait for the hosting emulator to accept connections.
           timeout 120 bash -c \
             'until curl -sf http://127.0.0.1:5000 > /dev/null 2>&1; do sleep 2; done'
           echo "Emulators ready"
 
+      - name: Generate E2E auth token
+        id: auth-token
+        run: |
+          RESPONSE=$(curl -sf -X POST \
+            "http://127.0.0.1:9099/identitytoolkit.googleapis.com/v1/accounts:signUp?key=fake-api-key" \
+            -H "Content-Type: application/json" \
+            -d '{"returnSecureToken":true}')
+          TOKEN=$(echo "$RESPONSE" | jq -r '.idToken')
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
       - name: Run E2E tests
         run: cd services/e2e && bunx vitest run
         env:
           E2E_BASE_URL: http://127.0.0.1:5000
-
-      # --- Preview deploy (visual review only, not used by e2e tests) ---
-
-      - name: Authenticate to Google Cloud
-        if: ${{ !cancelled() }}
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
-
-      - name: Deploy Hosting to preview channel
-        if: ${{ !cancelled() }}
-        run: |
-          bunx firebase-tools hosting:channel:deploy \
-            pr-${{ github.event.pull_request.number }} \
-            --expires 3d \
-            --project yoikme
-
-  # Delete the preview channel when the PR is closed (merged or abandoned).
-  cleanup:
-    name: Delete Preview Channel
-    if: github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.8"
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
-
-      - name: Delete preview channel
-        run: |
-          bunx firebase-tools hosting:channel:delete \
-            pr-${{ github.event.pull_request.number }} \
-            --project yoikme \
-            --force
+          E2E_AUTH_TOKEN: ${{ steps.auth-token.outputs.token }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,10 +6,11 @@ on:
     types: [opened, synchronize, reopened, closed]
 
 jobs:
-  # Deploy to a Firebase preview channel and run the e2e suite against it.
-  # Skipped when the PR is being closed (handled by the cleanup job below).
+  # Run e2e tests against Firebase emulators (functions + firestore + hosting).
+  # The hosting emulator applies the same rewrite rules as production, so the
+  # test suite hits identical URL paths without touching real infrastructure.
   e2e:
-    name: Deploy & Run E2E Tests
+    name: Run E2E Tests
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
@@ -49,36 +50,36 @@ jobs:
           rm -rf $GITHUB_WORKSPACE/functions/node_modules
           cp -r node_modules $GITHUB_WORKSPACE/functions/node_modules
 
+      - name: Start Firebase emulators
+        run: |
+          bunx firebase-tools emulators:start \
+            --only functions,firestore,hosting \
+            --project yoikme &
+          # Wait for the hosting emulator to accept connections.
+          timeout 120 bash -c \
+            'until curl -sf http://127.0.0.1:5000 > /dev/null 2>&1; do sleep 2; done'
+          echo "Emulators ready"
+
+      - name: Run E2E tests
+        run: cd services/e2e && bunx vitest run
+        env:
+          E2E_BASE_URL: http://127.0.0.1:5000
+
+      # --- Preview deploy (visual review only, not used by e2e tests) ---
+
       - name: Authenticate to Google Cloud
+        if: ${{ !cancelled() }}
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
 
-      # Functions are deployed globally (shared across all preview channels).
-      - name: Deploy Cloud Functions
-        run: bunx firebase-tools deploy --only functions --project yoikme
-
-      # Hosting is deployed to an ephemeral preview channel scoped to this PR.
-      # The --json flag makes firebase-tools emit structured output so we can
-      # reliably extract the preview URL regardless of log noise.
       - name: Deploy Hosting to preview channel
-        id: deploy-hosting
+        if: ${{ !cancelled() }}
         run: |
-          DEPLOY_OUTPUT=$(bunx firebase-tools hosting:channel:deploy \
+          bunx firebase-tools hosting:channel:deploy \
             pr-${{ github.event.pull_request.number }} \
             --expires 3d \
-            --project yoikme \
-            --json)
-          echo "$DEPLOY_OUTPUT"
-          PREVIEW_URL=$(echo "$DEPLOY_OUTPUT" | jq -r '.result.yoikme.url')
-          echo "url=$PREVIEW_URL" >> $GITHUB_OUTPUT
-
-      # E2E_BASE_URL is the preview channel root; tests append paths like
-      # /api/posts which are rewritten by Hosting to the Cloud Function.
-      - name: Run E2E tests
-        run: cd services/e2e && bunx vitest run
-        env:
-          E2E_BASE_URL: ${{ steps.deploy-hosting.outputs.url }}
+            --project yoikme
 
   # Delete the preview channel when the PR is closed (merged or abandoned).
   cleanup:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,110 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [trunk]
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  # Deploy to a Firebase preview channel and run the e2e suite against it.
+  # Skipped when the PR is being closed (handled by the cleanup job below).
+  e2e:
+    name: Deploy & Run E2E Tests
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.8"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build client
+        run: cd services/client && bunx vite build
+
+      - name: Bundle Cloud Functions
+        run: cd functions && node build.mjs
+
+      - name: Install functions production dependencies
+        run: |
+          # Copy functions dir outside the monorepo so npm doesn't
+          # walk up and encounter workspace:* protocol references.
+          cp -r functions /tmp/functions-stage
+          cd /tmp/functions-stage
+          npm install --omit=dev
+          # Copy the resolved node_modules back
+          rm -rf $GITHUB_WORKSPACE/functions/node_modules
+          cp -r node_modules $GITHUB_WORKSPACE/functions/node_modules
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+
+      # Functions are deployed globally (shared across all preview channels).
+      - name: Deploy Cloud Functions
+        run: bunx firebase-tools deploy --only functions --project yoikme
+
+      # Hosting is deployed to an ephemeral preview channel scoped to this PR.
+      # The --json flag makes firebase-tools emit structured output so we can
+      # reliably extract the preview URL regardless of log noise.
+      - name: Deploy Hosting to preview channel
+        id: deploy-hosting
+        run: |
+          DEPLOY_OUTPUT=$(bunx firebase-tools hosting:channel:deploy \
+            pr-${{ github.event.pull_request.number }} \
+            --expires 3d \
+            --project yoikme \
+            --json)
+          echo "$DEPLOY_OUTPUT"
+          PREVIEW_URL=$(echo "$DEPLOY_OUTPUT" | jq -r '.result.yoikme.url')
+          echo "url=$PREVIEW_URL" >> $GITHUB_OUTPUT
+
+      # E2E_BASE_URL is the preview channel root; tests append paths like
+      # /api/posts which are rewritten by Hosting to the Cloud Function.
+      - name: Run E2E tests
+        run: cd services/e2e && bunx vitest run
+        env:
+          E2E_BASE_URL: ${{ steps.deploy-hosting.outputs.url }}
+
+  # Delete the preview channel when the PR is closed (merged or abandoned).
+  cleanup:
+    name: Delete Preview Channel
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.8"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+
+      - name: Delete preview channel
+        run: |
+          bunx firebase-tools hosting:channel:delete \
+            pr-${{ github.event.pull_request.number }} \
+            --project yoikme \
+            --force

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,12 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,4 +79,5 @@ jobs:
         run: cd services/e2e && bunx vitest run
         env:
           E2E_BASE_URL: http://127.0.0.1:5000
+          FIREBASE_AUTH_EMULATOR_HOST: 127.0.0.1:9099
           E2E_AUTH_TOKEN: ${{ steps.auth-token.outputs.token }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,71 @@
+name: Preview Deployment
+
+on:
+  pull_request:
+    branches: [trunk]
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - "services/client/**"
+
+jobs:
+  deploy-preview:
+    name: Deploy Preview
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.8"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build client
+        run: cd services/client && bunx vite build
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+
+      - name: Deploy Hosting to preview channel
+        run: |
+          bunx firebase-tools hosting:channel:deploy \
+            pr-${{ github.event.pull_request.number }} \
+            --expires 3d \
+            --project yoikme
+
+  cleanup:
+    name: Delete Preview Channel
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.8"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+
+      - name: Delete preview channel
+        run: |
+          bunx firebase-tools hosting:channel:delete \
+            pr-${{ github.event.pull_request.number }} \
+            --project yoikme \
+            --force

--- a/bun.lock
+++ b/bun.lock
@@ -83,6 +83,15 @@
         "vitest": "^3.2.4",
       },
     },
+    "services/e2e": {
+      "name": "@yme/e2e",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@yme/tsconfig": "workspace:*",
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.4",
+      },
+    },
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
@@ -556,6 +565,8 @@
     "@yme/api": ["@yme/api@workspace:services/api"],
 
     "@yme/client": ["@yme/client@workspace:services/client"],
+
+    "@yme/e2e": ["@yme/e2e@workspace:services/e2e"],
 
     "@yme/functions": ["@yme/functions@workspace:functions"],
 

--- a/firebase.json
+++ b/firebase.json
@@ -7,8 +7,7 @@
         "source": "/api/**",
         "function": {
           "functionId": "api",
-          "region": "us-east1",
-          "pinTag": true
+          "region": "us-east1"
         }
       },
       {

--- a/firebase.json
+++ b/firebase.json
@@ -5,7 +5,11 @@
     "rewrites": [
       {
         "source": "/api/**",
-        "function": "api"
+        "function": {
+          "functionId": "api",
+          "region": "us-east1",
+          "pinTag": true
+        }
       },
       {
         "source": "**",

--- a/firebase.json
+++ b/firebase.json
@@ -31,6 +31,9 @@
     }
   ],
   "emulators": {
+    "auth": {
+      "port": 9099
+    },
     "functions": {
       "port": 5001
     },

--- a/firebase.json
+++ b/firebase.json
@@ -30,5 +30,16 @@
         "*.local"
       ]
     }
-  ]
+  ],
+  "emulators": {
+    "functions": {
+      "port": 5001
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "hosting": {
+      "port": 5000
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "client": "bun run --filter @yme/client",
     "develop": "turbo run develop --no-cache --parallel --continue",
     "api": "bun run --filter @yme/api",
-    "test": "turbo run test"
+    "test": "turbo run test",
+    "test:e2e": "bun run --filter @yme/e2e test:e2e",
+    "test:e2e:production": "bun run --filter @yme/e2e test:e2e:production"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.4.2",

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -13,6 +13,17 @@ import { comments } from "./routes/comments"
 
 const app = new Hono()
 
+// Global error handler — catch unhandled exceptions and return structured JSON
+// instead of a raw 500. This prevents Hono's default HTML error page from
+// leaking to API consumers and ensures clients always get valid JSON.
+app.onError((err, c) => {
+  if (err instanceof SyntaxError && err.message.includes("JSON")) {
+    return c.json({ error: "Invalid or missing JSON body" }, 400)
+  }
+  console.error("Unhandled error:", err)
+  return c.json({ error: "Internal server error" }, 500)
+})
+
 // Middleware.
 app.use("*", logger())
 app.use("*", cors())

--- a/services/api/src/functions.ts
+++ b/services/api/src/functions.ts
@@ -38,10 +38,10 @@ export const api = onRequest(
       headers,
       body:
         rawBody && rawBody.byteLength > 0
-          ? rawBody.buffer.slice(
+          ? (rawBody.buffer.slice(
               rawBody.byteOffset,
               rawBody.byteOffset + rawBody.byteLength
-            )
+            ) as ArrayBuffer)
           : undefined,
     })
 

--- a/services/api/src/functions.ts
+++ b/services/api/src/functions.ts
@@ -26,15 +26,23 @@ export const api = onRequest(
     // Cloud Functions v2 pre-parses the request body, so the raw stream is
     // already consumed. Use `req.rawBody` (a Buffer provided by the runtime)
     // instead of reading from the stream, which would hang forever.
-    const body =
+    // Note: Buffer.buffer returns the full underlying ArrayBuffer (pool-
+    // allocated), so we must slice to the correct region.
+    const rawBody =
       req.method !== "GET" && req.method !== "HEAD"
-        ? (req as any).rawBody || undefined
+        ? ((req as any).rawBody as Buffer | undefined)
         : undefined
 
     const webRequest = new Request(url, {
       method: req.method,
       headers,
-      body: body ? (body.buffer as ArrayBuffer) : undefined,
+      body:
+        rawBody && rawBody.byteLength > 0
+          ? rawBody.buffer.slice(
+              rawBody.byteOffset,
+              rawBody.byteOffset + rawBody.byteLength
+            )
+          : undefined,
     })
 
     // Run through Hono.

--- a/services/e2e/README.md
+++ b/services/e2e/README.md
@@ -1,0 +1,47 @@
+# End-to-End Tests
+
+Functional API tests for yoik.me. These tests make real HTTP requests against
+a running API instance, making them suitable for pre- and post-deployment
+verification.
+
+## Quick start
+
+```bash
+# From the repo root — run against local dev server (localhost:3001):
+bun run test:e2e
+
+# Run against production:
+bun run test:e2e:production
+```
+
+## Configuration
+
+| Variable         | Description                       | Default                 |
+| ---------------- | --------------------------------- | ----------------------- |
+| `E2E_BASE_URL`   | API base URL to test against      | `http://localhost:3001` |
+| `E2E_AUTH_TOKEN` | Firebase ID token for write tests | _(unset — skips write)_ |
+
+### Getting an auth token
+
+Write tests (creating posts/comments) require a valid Firebase ID token. You
+can obtain one from the browser dev tools after logging in to the app:
+
+1. Open the app and sign in.
+2. In the browser console: `await firebase.auth().currentUser.getIdToken()`
+3. Export it: `export E2E_AUTH_TOKEN="<token>"`
+
+**Note:** Firebase ID tokens expire after 1 hour.
+
+## What's tested
+
+- **Health check** — API reachability and basic response.
+- **Posts** — Listing, pagination, single-post retrieval, creation (auth), validation.
+- **Comments** — Listing, creation (auth), validation, error handling.
+- **CORS & HTTP edge cases** — Preflight requests, malformed bodies, unexpected
+  content types (addresses issues like #33 where POST requests returned 502).
+
+## Test design
+
+Tests are designed to run against **any environment** (local, staging, production)
+without setup or teardown. Read-only tests always run; write tests are gated
+behind `E2E_AUTH_TOKEN` and are automatically skipped when it's not set.

--- a/services/e2e/README.md
+++ b/services/e2e/README.md
@@ -31,9 +31,9 @@ bun run test:e2e:production
 
 ## Configuration
 
-| Variable       | Description                       | Default                 |
-| -------------- | --------------------------------- | ----------------------- |
-| `E2E_BASE_URL` | API base URL to test against      | `http://localhost:3001` |
+| Variable       | Description                  | Default                 |
+| -------------- | ---------------------------- | ----------------------- |
+| `E2E_BASE_URL` | API base URL to test against | `http://localhost:3001` |
 
 ### Firebase emulator ports (configured in `firebase.json`)
 

--- a/services/e2e/README.md
+++ b/services/e2e/README.md
@@ -4,11 +4,26 @@ Functional API tests for yoik.me. These tests make real HTTP requests against
 a running API instance, making them suitable for pre- and post-deployment
 verification.
 
+## How it works
+
+In CI, tests run against **Firebase emulators** (functions + firestore +
+hosting), not production. The hosting emulator applies the same rewrite rules as
+production (`/api/**` → Cloud Function), so the test suite hits identical URL
+paths without touching real infrastructure. Firestore is completely isolated per
+run — the emulator starts with an empty database every time.
+
+The hosting preview channel deploy still runs (for visual review by PR
+reviewers) but the e2e test suite does **not** depend on it.
+
 ## Quick start
 
 ```bash
 # From the repo root — run against local dev server (localhost:3001):
 bun run test:e2e
+
+# Run against local emulators (start emulators first):
+bunx firebase-tools emulators:start --only functions,firestore,hosting --project yoikme
+E2E_BASE_URL=http://localhost:5000 bun run test:e2e
 
 # Run against production:
 bun run test:e2e:production
@@ -16,21 +31,17 @@ bun run test:e2e:production
 
 ## Configuration
 
-| Variable         | Description                       | Default                 |
-| ---------------- | --------------------------------- | ----------------------- |
-| `E2E_BASE_URL`   | API base URL to test against      | `http://localhost:3001` |
-| `E2E_AUTH_TOKEN` | Firebase ID token for write tests | _(unset — skips write)_ |
+| Variable       | Description                       | Default                 |
+| -------------- | --------------------------------- | ----------------------- |
+| `E2E_BASE_URL` | API base URL to test against      | `http://localhost:3001` |
 
-### Getting an auth token
+### Firebase emulator ports (configured in `firebase.json`)
 
-Write tests (creating posts/comments) require a valid Firebase ID token. You
-can obtain one from the browser dev tools after logging in to the app:
-
-1. Open the app and sign in.
-2. In the browser console: `await firebase.auth().currentUser.getIdToken()`
-3. Export it: `export E2E_AUTH_TOKEN="<token>"`
-
-**Note:** Firebase ID tokens expire after 1 hour.
+| Emulator  | Port |
+| --------- | ---- |
+| Hosting   | 5000 |
+| Functions | 5001 |
+| Firestore | 8080 |
 
 ## What's tested
 
@@ -42,6 +53,8 @@ can obtain one from the browser dev tools after logging in to the app:
 
 ## Test design
 
-Tests are designed to run against **any environment** (local, staging, production)
-without setup or teardown. Read-only tests always run; write tests are gated
-behind `E2E_AUTH_TOKEN` and are automatically skipped when it's not set.
+Tests are designed to run against **any environment** (emulators, local dev,
+production) without setup or teardown. Read-only tests always run; write tests
+are gated behind `E2E_AUTH_TOKEN` and are automatically skipped when it's not
+set. With the emulator's empty database, read-only tests gracefully handle empty
+result sets (pagination, schema checks guard on `items.length > 0`).

--- a/services/e2e/package.json
+++ b/services/e2e/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "test:production": "E2E_BASE_URL=https://yoikme.web.app vitest run"
+    "test:e2e": "vitest run",
+    "test:e2e:watch": "vitest",
+    "test:e2e:production": "E2E_BASE_URL=https://yoikme.web.app vitest run"
   },
   "devDependencies": {
     "@yme/tsconfig": "workspace:*",

--- a/services/e2e/package.json
+++ b/services/e2e/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@yme/e2e",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:production": "E2E_BASE_URL=https://yoikme.web.app vitest run"
+  },
+  "devDependencies": {
+    "@yme/tsconfig": "workspace:*",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/services/e2e/src/comments.test.ts
+++ b/services/e2e/src/comments.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Comments endpoint e2e tests.
+ *
+ * Tests listing and creating comments on posts, including auth
+ * requirements, validation, and error handling.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest"
+import { api, uniqueId } from "./helpers"
+
+const AUTH_TOKEN = process.env.E2E_AUTH_TOKEN
+
+/** Fetches the first available post ID, or undefined if none exist. */
+async function getFirstPostId(): Promise<string | undefined> {
+  const res = await api("/api/posts?limit=1")
+  const body = await res.json()
+  return body.items[0]?.postId
+}
+
+describe("GET /api/posts/:postId/comments", () => {
+  let postId: string | undefined
+
+  beforeAll(async () => {
+    postId = await getFirstPostId()
+  })
+
+  it("returns paginated response for an existing post", async () => {
+    if (!postId) return
+    const res = await api(`/api/posts/${postId}/comments`)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveProperty("items")
+    expect(Array.isArray(body.items)).toBe(true)
+  })
+
+  it("returns comments with expected schema", async () => {
+    if (!postId) return
+    const res = await api(`/api/posts/${postId}/comments?limit=1`)
+    const body = await res.json()
+    if (body.items.length > 0) {
+      const comment = body.items[0]
+      expect(comment).toHaveProperty("commentId")
+      expect(comment).toHaveProperty("postId", postId)
+      expect(comment).toHaveProperty("body")
+      expect(comment).toHaveProperty("published")
+      expect(comment).toHaveProperty("author")
+    }
+  })
+})
+
+describe("POST /api/posts/:postId/comments", () => {
+  let postId: string | undefined
+
+  beforeAll(async () => {
+    postId = await getFirstPostId()
+  })
+
+  it("returns 401 without an auth token (not 5xx)", async () => {
+    if (!postId) return
+    const res = await api(`/api/posts/${postId}/comments`, {
+      method: "POST",
+      body: JSON.stringify({ body: "should fail" }),
+    })
+    expect(res.status).toBeLessThan(500)
+    expect(res.status).toBe(401)
+  }, 60_000)
+
+  it("returns 401 with an invalid auth token (not 5xx)", async () => {
+    if (!postId) return
+    const res = await api(`/api/posts/${postId}/comments`, {
+      method: "POST",
+      body: JSON.stringify({ body: "should fail" }),
+      headers: { Authorization: "Bearer invalid-token" },
+    })
+    expect(res.status).toBeLessThan(500)
+    expect(res.status).toBe(401)
+  }, 60_000)
+
+  it.skipIf(!AUTH_TOKEN)(
+    "returns 404 for a nonexistent post",
+    async () => {
+      const res = await api("/api/posts/nonexistent-id-12345/comments", {
+        method: "POST",
+        body: JSON.stringify({ body: "orphaned comment" }),
+        headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+      })
+      expect(res.status).toBe(404)
+    },
+    60_000
+  )
+
+  it.skipIf(!AUTH_TOKEN)(
+    "creates a comment with a valid auth token",
+    async () => {
+      if (!postId) return
+      const content = `Test comment ${uniqueId()}`
+      const res = await api(`/api/posts/${postId}/comments`, {
+        method: "POST",
+        body: JSON.stringify({ body: content }),
+        headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+      })
+      expect(res.status).toBeLessThan(500)
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body).toHaveProperty("commentId")
+    },
+    60_000
+  )
+
+  it.skipIf(!AUTH_TOKEN)(
+    "returns 400 for an empty comment body",
+    async () => {
+      if (!postId) return
+      const res = await api(`/api/posts/${postId}/comments`, {
+        method: "POST",
+        body: JSON.stringify({ body: "" }),
+        headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+      })
+      expect(res.status).toBe(400)
+    },
+    60_000
+  )
+})

--- a/services/e2e/src/cors.test.ts
+++ b/services/e2e/src/cors.test.ts
@@ -1,0 +1,40 @@
+/**
+ * CORS and HTTP edge-case tests.
+ *
+ * Ensures the API handles cross-origin requests and malformed input
+ * without returning 5xx errors (regression coverage for #33).
+ */
+
+import { describe, it, expect } from "vitest"
+import { api } from "./helpers"
+
+describe("CORS headers", () => {
+  it("includes CORS headers on API responses", async () => {
+    const res = await api("/api/posts?limit=1")
+    expect(res.headers.get("access-control-allow-origin")).toBeTruthy()
+  })
+})
+
+describe("HTTP edge cases", () => {
+  it("returns 404 for unknown API routes", async () => {
+    const res = await api("/api/nonexistent-route")
+    expect(res.status).toBe(404)
+  })
+
+  it("handles POST with various content types without 5xx", async () => {
+    const res = await api("/api/posts", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "body=test",
+    })
+    expect(res.status).toBeLessThan(500)
+  }, 60_000)
+
+  it("handles POST with empty body without 5xx", async () => {
+    const res = await api("/api/posts", {
+      method: "POST",
+      body: "",
+    })
+    expect(res.status).toBeLessThan(500)
+  }, 60_000)
+})

--- a/services/e2e/src/health.test.ts
+++ b/services/e2e/src/health.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Health check and smoke tests.
+ *
+ * Verifies the API is reachable. The /health endpoint is only
+ * available when hitting the API directly; in production, Firebase
+ * Hosting routes /api/** to the function but /health serves the SPA.
+ */
+
+import { describe, it, expect } from "vitest"
+import { api } from "./helpers"
+
+describe("API reachability", () => {
+  it("GET /api/posts returns 200", async () => {
+    const res = await api("/api/posts?limit=1")
+    expect(res.status).toBe(200)
+  })
+
+  it("responds with JSON content type", async () => {
+    const res = await api("/api/posts?limit=1")
+    expect(res.headers.get("content-type")).toContain("application/json")
+  })
+})

--- a/services/e2e/src/helpers.ts
+++ b/services/e2e/src/helpers.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared helpers for e2e tests.
+ */
+
+/** Base URL for the API under test. Defaults to local dev server. */
+export const BASE_URL = (
+  process.env.E2E_BASE_URL || "http://localhost:3001"
+).replace(/\/$/, "")
+
+/**
+ * Typed fetch wrapper that prepends the base URL and sets JSON headers.
+ */
+export async function api(
+  path: string,
+  options: RequestInit = {}
+): Promise<Response> {
+  const url = `${BASE_URL}${path}`
+  const headers = new Headers(options.headers)
+  if (options.body && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json")
+  }
+  return fetch(url, { ...options, headers })
+}
+
+/**
+ * Generate a unique string for test isolation.
+ */
+export function uniqueId(): string {
+  return `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}

--- a/services/e2e/src/helpers.ts
+++ b/services/e2e/src/helpers.ts
@@ -2,7 +2,13 @@
  * Shared helpers for e2e tests.
  */
 
-/** Base URL for the API under test. Defaults to local dev server. */
+/**
+ * Base URL for the API under test.
+ *
+ * - CI:         http://127.0.0.1:5000  (Firebase hosting emulator)
+ * - Local dev:  http://localhost:3001   (Bun dev server, default)
+ * - Production: https://yoikme.web.app  (set via E2E_BASE_URL)
+ */
 export const BASE_URL = (
   process.env.E2E_BASE_URL || "http://localhost:3001"
 ).replace(/\/$/, "")

--- a/services/e2e/src/posts.test.ts
+++ b/services/e2e/src/posts.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Posts endpoint e2e tests.
+ *
+ * Tests the full lifecycle of posts: listing, creation (auth-gated),
+ * single-post retrieval, pagination, and error handling.
+ *
+ * NOTE: POST endpoints require a valid Firebase auth token. Tests that
+ * create resources are skipped when E2E_AUTH_TOKEN is not set, allowing
+ * the read-only suite to run against any environment without credentials.
+ */
+
+import { describe, it, expect } from "vitest"
+import { api, uniqueId } from "./helpers"
+
+const AUTH_TOKEN = process.env.E2E_AUTH_TOKEN
+
+describe("GET /api/posts", () => {
+  it("returns 200 with paginated response shape", async () => {
+    const res = await api("/api/posts")
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveProperty("items")
+    expect(Array.isArray(body.items)).toBe(true)
+  })
+
+  it("respects the limit query parameter", async () => {
+    const res = await api("/api/posts?limit=2")
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.items.length).toBeLessThanOrEqual(2)
+  })
+
+  it("returns posts with expected schema", async () => {
+    const res = await api("/api/posts?limit=1")
+    const body = await res.json()
+    if (body.items.length > 0) {
+      const post = body.items[0]
+      expect(post).toHaveProperty("postId")
+      expect(post).toHaveProperty("body")
+      expect(post).toHaveProperty("published")
+      expect(post).toHaveProperty("author")
+      expect(post.author).toHaveProperty("uid")
+      expect(post.author).toHaveProperty("color")
+      expect(post.author).toHaveProperty("username")
+    }
+  })
+
+  it("supports cursor-based pagination", async () => {
+    const first = await api("/api/posts?limit=1")
+    const firstBody = await first.json()
+    if (firstBody.cursor) {
+      const second = await api(`/api/posts?limit=1&cursor=${firstBody.cursor}`)
+      expect(second.status).toBe(200)
+      const secondBody = await second.json()
+      expect(Array.isArray(secondBody.items)).toBe(true)
+      if (secondBody.items.length > 0) {
+        expect(secondBody.items[0].postId).not.toBe(firstBody.items[0].postId)
+      }
+    }
+  })
+})
+
+describe("GET /api/posts/:id", () => {
+  it("returns 404 for a nonexistent post", async () => {
+    const res = await api("/api/posts/nonexistent-id-12345")
+    expect(res.status).toBe(404)
+  })
+
+  it("returns a valid post when one exists", async () => {
+    const list = await api("/api/posts?limit=1")
+    const listBody = await list.json()
+    if (listBody.items.length > 0) {
+      const id = listBody.items[0].postId
+      const res = await api(`/api/posts/${id}`)
+      expect(res.status).toBe(200)
+      const post = await res.json()
+      expect(post.postId).toBe(id)
+    }
+  })
+})
+
+describe("POST /api/posts", () => {
+  /**
+   * These tests verify POST requests are handled without 5xx errors.
+   * Issue #33 reported 502 responses on POST — these catch regressions.
+   * 60s timeout accommodates Cloud Functions cold starts.
+   */
+  it("returns 401 without an auth token (not 5xx)", async () => {
+    const res = await api("/api/posts", {
+      method: "POST",
+      body: JSON.stringify({ body: "should fail" }),
+    })
+    expect(res.status).toBeLessThan(500)
+    expect(res.status).toBe(401)
+  }, 60_000)
+
+  it("returns 401 with an invalid auth token (not 5xx)", async () => {
+    const res = await api("/api/posts", {
+      method: "POST",
+      body: JSON.stringify({ body: "should fail" }),
+      headers: { Authorization: "Bearer invalid-token" },
+    })
+    expect(res.status).toBeLessThan(500)
+    expect(res.status).toBe(401)
+  }, 60_000)
+
+  it.skipIf(!AUTH_TOKEN)(
+    "creates a post with a valid auth token",
+    async () => {
+      const content = `Test post ${uniqueId()}`
+      const res = await api("/api/posts", {
+        method: "POST",
+        body: JSON.stringify({ body: content }),
+        headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+      })
+      // Critical regression test for issue #33.
+      expect(res.status).toBeLessThan(500)
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body).toHaveProperty("postId")
+    },
+    60_000
+  )
+
+  it.skipIf(!AUTH_TOKEN)(
+    "returns 400 for an empty post body",
+    async () => {
+      const res = await api("/api/posts", {
+        method: "POST",
+        body: JSON.stringify({ body: "" }),
+        headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+      })
+      expect(res.status).toBe(400)
+    },
+    60_000
+  )
+
+  it.skipIf(!AUTH_TOKEN)(
+    "returns 400 for a whitespace-only post body",
+    async () => {
+      const res = await api("/api/posts", {
+        method: "POST",
+        body: JSON.stringify({ body: "   " }),
+        headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+      })
+      expect(res.status).toBe(400)
+    },
+    60_000
+  )
+})

--- a/services/e2e/tsconfig.json
+++ b/services/e2e/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@yme/tsconfig/base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "types": ["vitest/globals"]
+  },
+  "include": ["src"]
+}

--- a/services/e2e/vitest.config.ts
+++ b/services/e2e/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    globals: true,
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+})


### PR DESCRIPTION
### Issue reference

Closes #34

### Description of the change

Adds a new `@yme/e2e` service with vitest-based functional tests that make real HTTP requests against a configurable API endpoint. The suite is designed to run before and after deployments to catch issues like the 502 from #33.

**Test coverage:**
- Health/smoke checks for API reachability
- Posts: listing, pagination, schema validation, single-post retrieval
- Comments: listing, schema validation, auth requirements
- POST endpoints: auth enforcement (401), input validation (400), and explicit `< 500` assertions to catch 5xx regressions
- CORS headers and HTTP edge cases (malformed bodies, wrong content types)

**Design decisions:**
- Tests run against any environment via `E2E_BASE_URL` (defaults to `localhost:3001`)
- Write tests are gated behind `E2E_AUTH_TOKEN` and auto-skip when not set
- Excluded from `turbo run test` since e2e requires a running API server
- 60s timeouts on POST tests to accommodate Cloud Functions cold starts

**Usage:**
```bash
bun run test:e2e              # against local dev server
bun run test:e2e:production   # against production
```

### Additional context

Running against production revealed that all POST requests currently timeout (>60s), confirming the issue described in #33. All 12 GET-based tests pass against production. The POST test failures are real production bugs, not test bugs — exactly the kind of regression this suite is designed to catch.